### PR TITLE
[osx] Increase CAEngine buffer size (n_frames) by 4 times

### DIFF
--- a/macosx/kext/AudioEngine.cpp
+++ b/macosx/kext/AudioEngine.cpp
@@ -60,8 +60,13 @@ bool kXAudioEngine::init(kx_hw *hw_)
 		bps=16;
     
     n_channels=8; // should be <= MAX_CHANNELS_
-    
-    n_frames = (int)(hw->mtr_buffer.size * 8 / bps / n_channels);
+
+		// Use 4 times the buffer size to prevent some sort of underrun on
+		// Mavericks (related to Timer Coalescing?) causing playback crackle
+		// until streams are restart (e.g. stop/start playback)
+    n_frames = (int)(4 * (hw->mtr_buffer.size * 8 / bps / n_channels));
+
+    debug("kXAudioEngine[%p]::init - n_frames=%d\n", this, n_frames);
     
     is_running=0;
     


### PR DESCRIPTION
Closes https://github.com/kxproject/kx-audio-driver/issues/5.

It seems that on Mavericks, something (the Timer Coalescing thing?) can cause a buffer over/underrun, resulting in (wild guess!) CAEngine and the hardware getting out of sync which will make playback crackle heavily. Increasing the Engine buffer prevents this from happening.

(NB: Someone with better knowledge of OSX Kernel/Driver/CoreAudio and the E-mu hardware should probably fix this properly, but I have a feeling the former as well as (and especially) the latter are getting really rare nowadays due to people rather sticking to motherboard audio et al...)
